### PR TITLE
Enable IMEI fetch endpoints

### DIFF
--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -107,6 +107,22 @@ router.put("/api/imeis/:id", ({ body, params }, res) => {
     });
 });
 
+// return all imei request logs sorted by creation date
+router.get("/api/imeis", (req, res) => {
+  Imei.find()
+    .sort({ day: -1 })
+    .then((dbImeis) => res.json(dbImeis))
+    .catch((err) => res.status(400).json(err));
+});
+
+// return all imei results stored in the secondary collection
+router.get("/api/imei1", (req, res) => {
+  Imei1.find()
+    .sort({ day: -1 })
+    .then((dbImei1) => res.json(dbImei1))
+    .catch((err) => res.status(400).json(err));
+});
+
 // router.get("/api/imeis", (req, res) => {
 //   console.log("111");
 //   Imei.find()


### PR DESCRIPTION
## Summary
- enable `/api/imeis` and `/api/imei1` endpoints for retrieving stored IMEI logs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68430bc4c380832dabf428affa5fd9c5