### PR TITLE
Add jest testing framework and basic API test

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "node server.js",
     "watch": "nodemon server.js",
     "seed": "node seeders/seed.js"
@@ -22,7 +22,10 @@
     "seeder": "^0.2.4"
   },
   "keywords": [],
-  "devDependencies": {},
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "supertest": "^6.0.0"
+  },
   "description": "simple imei checker",
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -36,6 +36,11 @@ mongoose.connect(MONGODB_URI , {
 app.use(require("./routes/api-routes.js"));
 app.use(require("./routes/html-routes.js"));
 
-app.listen(PORT, () => {
-  console.log(`App running on port http://localhost:${PORT}`);
-});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`App running on port http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('GET /api/imei1F/:imei', () => {
+  it('responds with 200', async () => {
+    const imei = '123456789012345';
+    const res = await request(app).get(`/api/imei1F/${imei}`);
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add jest and supertest dev dependencies
- export the Express app from `server.js`
- add API test for `/api/imei1F/:imei`
- use jest for the test npm script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430d5cc91c832d8ba332cd7c0f65b6