### PR TITLE
Remove egs from lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -327,14 +327,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "egs": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/egs/-/egs-0.3.1.tgz",
-      "integrity": "sha1-aDRHvZr0sehuOwyUvEoKu7VrpIc=",
-      "requires": {
-        "gorillascript": "~0.9.4"
-      }
-    },
     "ejs": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.7.tgz",


### PR DESCRIPTION
## Summary
- remove unused `egs` package entry from lockfile

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684310e4a814832d85c6a79e7bfcbaf1