### PR TITLE
Replace request with node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mongoose": "^5.10.9",
     "morgan": "^1.10.0",
     "path": "^0.12.7",
-    "request": "^2.88.2",
+    "node-fetch": "^2.6.7",
     "seeder": "^0.2.4"
   },
   "keywords": [],

--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -2,7 +2,7 @@ const path = require("path");
 const router = require("express").Router();
 const bodyParser= require("body-parser");
 // const { redirect } = require("express/lib/response");
-const request = require("request");
+const fetch = global.fetch || ((...args) => import('node-fetch').then(({default: f}) => f(...args)));
 
 
   router.get("/result", (req, res) => {
@@ -53,19 +53,25 @@ const request = require("request");
     res.render("test1.ejs");
   // res.render("test1.ejs");
   });
-  router.get("/result1", (req, res)=>{
-    let imei= req.query.search;
+  router.get("/result1", async (req, res) => {
+    let imei = req.query.search;
     console.log(imei);
     // let imei= "353283075129556";
-    request('https://imeidb.xyz/api/imei/' + imei + '?token=' + process.env.IMEI_API_TOKEN + '&format=json', (error,response,body) => {
+    try {
+      const response = await fetch(
+        "https://imeidb.xyz/api/imei/" +
+          imei +
+          "?token=" +
+          process.env.IMEI_API_TOKEN +
+          "&format=json"
+      );
+      const data = await response.json();
+      res.render("imeis.ejs", { data });
+    } catch (error) {
+      console.log(error);
+      res.status(500).send({ message: "Failed to fetch IMEI" });
+    }
 
-      if (error){
-        console.log(error);
-      }
-      let data= JSON.parse(body);
-      res.render("imeis.ejs",{data:data});
-    });
-    
   // res.render("test1.ejs");
   });
   


### PR DESCRIPTION
## Summary
- swap deprecated `request` calls for `node-fetch`
- update API and HTML routes to async/await style
- declare `node-fetch` dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684325f478f8832d92e9c2a0ae231ece