### PR TITLE
Show stored phone model info

### DIFF
--- a/public/api.js
+++ b/public/api.js
@@ -159,4 +159,15 @@ export const API = {
 
     return json;
   },
+
+  async getPhoneModel(model) {
+    try {
+      const res = await fetch(`/api/phone-model/${encodeURIComponent(model)}`);
+      if (res.status !== 200) return null;
+      return await res.json();
+    } catch (err) {
+      console.log(err);
+      return null;
+    }
+  },
 };

--- a/public/funk.js
+++ b/public/funk.js
@@ -4,7 +4,7 @@
 //  Assume necessary DOM elements and imports are already defined
 import { API } from "/api.js";
 console.log("this is the optimized funk from th second batch ");
-export function processImeiActual(response, type) {
+export async function processImeiActual(response, type) {
 const sampleResponse = response;
 console.log(sampleResponse.message + "dodu!");
 
@@ -83,10 +83,10 @@ overallScore,
 if (type === "api_result") {
 saveTodatabase(deviceInfo);
 }
-renderResults(deviceInfo);
+await renderResults(deviceInfo);
 }
 
-function renderResults(info) {
+async function renderResults(info) {
 const display = val => (val === undefined || val === null || val === '' ? 'N/A' : val);
 const getClassRemark = score => {
 if (score > 74) return ["green-score", "expecting good signal."];
@@ -125,6 +125,27 @@ const sampleDump =
 
 $("#score-dump").html(scoreDump);
 $("#main-dump").html(sampleDump);
+
+  $("#model-dump").html("");
+  if (info.model) {
+    const modelInfo = await API.getPhoneModel(info.model);
+    if (modelInfo) {
+      const bands = Array.isArray(modelInfo.bands)
+        ? modelInfo.bands.join(", ")
+        : typeof modelInfo.bands === "object"
+        ? Object.values(modelInfo.bands).join(", ")
+        : modelInfo.bands;
+      const compat = (modelInfo.compatibleModels || []).join(", ");
+      const modelDump = `
+        <table class="table table-striped">
+          <tr><th colspan="2">Stored Model Info</th></tr>
+          <tr><th>Model</th><td>${display(modelInfo.model)}</td></tr>
+          <tr><th>Bands</th><td>${display(bands)}</td></tr>
+          <tr><th>Compatible Models</th><td>${display(compat)}</td></tr>
+        </table>`;
+      $("#model-dump").html(modelDump);
+    }
+  }
 }
 
 async function saveTodatabase(info) {

--- a/public/index.html
+++ b/public/index.html
@@ -46,6 +46,8 @@
             </div>
             <div id="main-dump">
             </div>
+            <div id="model-dump">
+            </div>
           </form>
         </div>
       </div>

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -121,6 +121,21 @@ router.post("/api/createmodel2", async (req, res) => {
   }
 });
 
+// Fetch stored phone model details
+router.get("/api/phone-model/:model", async (req, res) => {
+  try {
+    const model = req.params.model;
+    const record = await PhoneModel.findOne({ model });
+    if (!record) {
+      return res.status(404).send({ message: "Model not found" });
+    }
+    res.json(record);
+  } catch (err) {
+    console.log(err);
+    res.status(500).send({ message: "Something went wrong" });
+  }
+});
+
 //=====
 
 router.put("/api/imeis/:id", ({ body, params }, res) => {


### PR DESCRIPTION
## Summary
- add `/api/phone-model/:model` endpoint
- expose `getPhoneModel` in `public/api.js`
- create `#model-dump` section in `index.html`
- fetch and render model details in `funk.js`

## Testing
- `npm test --silent` *(fails: querySrv ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68556b83ff88832da260d193db9c6226