### PR TITLE
Always show model info table

### DIFF
--- a/public/funk.js
+++ b/public/funk.js
@@ -126,7 +126,16 @@ const sampleDump =
 $("#score-dump").html(scoreDump);
 $("#main-dump").html(sampleDump);
 
-  $("#model-dump").html("");
+  // Always render the model table so the labels remain visible
+  const placeholderDump = `
+    <table class="table table-striped">
+      <tr><th colspan="2">Stored Model Info</th></tr>
+      <tr><th>Model</th><td>${display(info.model)}</td></tr>
+      <tr><th>Bands</th><td>N/A</td></tr>
+      <tr><th>Compatible Models</th><td>N/A</td></tr>
+    </table>`;
+  $("#model-dump").html(placeholderDump);
+
   if (info.model) {
     const modelInfo = await API.getPhoneModel(info.model);
     if (modelInfo) {


### PR DESCRIPTION
## Summary
- keep the "Stored Model Info" table visible

## Testing
- `MONGODB_URI='mongodb://localhost:27017/test?connectTimeoutMS=1000' npm test`

------
https://chatgpt.com/codex/tasks/task_e_68556fd26a74832d85cbebfa1b492838