### PR TITLE
Add detailed phone model schema

### DIFF
--- a/models/phoneModel.js
+++ b/models/phoneModel.js
@@ -3,9 +3,24 @@ const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
 const phoneModelSchema = new Schema({
+  // Device model identifier (e.g. "SM-G991U")
   model: { type: String, required: true, unique: true },
-  bands: { type: Schema.Types.Mixed, default: {} },
-  compatibleModels: [String]
+  // Human friendly name such as "Galaxy S21"
+  modelName: String,
+  deviceImage: String,
+  netTech: String,
+  speed: String,
+  bands: {
+    twoG: [String],
+    wcdma: [String],
+    lte: [String],
+  },
+  scores: {
+    att4g: Number,
+    tmobile4g: Number,
+    verizon4g: Number,
+  },
+  compatibleModels: [String],
 });
 
 const PhoneModel = mongoose.model("PhoneModel", phoneModelSchema);


### PR DESCRIPTION
## Summary
- expand `PhoneModel` schema with descriptive fields such as image link, network details, and provider scores
- compute and store these fields when saving IMEI results

## Testing
- `npm install`
- `MONGODB_URI=mongodb://localhost:27017/test npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855711e46dc832db2706eece5b16656