### PR TITLE
Implement phone model save from client

### DIFF
--- a/public/api.js
+++ b/public/api.js
@@ -170,4 +170,19 @@ export const API = {
       return null;
     }
   },
+
+  async createPhoneModel(data) {
+    try {
+      const res = await fetch('/api/phone-model', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch (err) {
+      console.log(err);
+      return null;
+    }
+  },
 };

--- a/public/funk.js
+++ b/public/funk.js
@@ -82,6 +82,7 @@ overallScore,
 
 if (type === "api_result") {
 saveTodatabase(deviceInfo);
+await ensurePhoneModel(deviceInfo);
 }
 await renderResults(deviceInfo);
 }
@@ -162,6 +163,34 @@ const modelData = { requests: { ...info, type: "imei1" } };
 const result = await API.createModel2(modelData);
 console.log("Saved model:", result);
 };
+
+async function ensurePhoneModel(info) {
+  if (!info.model) return;
+  const existing = await API.getPhoneModel(info.model);
+  if (existing) return;
+  const record = {
+    deviceName: info.deviceName,
+    deviceImage: info.deviceImage,
+    brand: info.brand,
+    model: info.model,
+    controlNumber: info.controlNumber,
+    simSlots: info.simSlots,
+    usb: info.usb,
+    nettech: info.nettech,
+    speed: info.speed,
+    frequency: info.frequency,
+    frequencyArray2g: info.frequencyArray2g,
+    frequencyArrayLte: info.frequencyArrayLte,
+    frequencyArray5g: info.frequencyArray5g,
+    frequencyArrayTdd: info.frequencyArrayTdd,
+    frequencyArrayWcdma: info.frequencyArrayWcdma,
+    attScore: info.attScore,
+    tmobileScore: info.tmobileScore,
+    verizonScore: info.verizonScore,
+    overallScore: info.overallScore,
+  };
+  await API.createPhoneModel(record);
+}
 export function displayResult(result) {
   console.log(" displayresult activated");
 };

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -194,6 +194,27 @@ router.get("/api/phone-model/:model", async (req, res) => {
   }
 });
 
+router.post("/api/phone-model", async (req, res) => {
+  try {
+    const { model } = req.body;
+    if (!model) {
+      return res.status(400).send({ message: "Model is required" });
+    }
+    let record = await PhoneModel.findOne({ model });
+    if (record) {
+      return res.json(record);
+    }
+    record = await PhoneModel.create(req.body);
+    res.json(record);
+  } catch (err) {
+    console.log(err);
+    if (err.name === "ValidationError") {
+      return res.status(400).send(err.errors);
+    }
+    res.status(500).send({ message: "Something went wrong" });
+  }
+});
+
 //=====
 
 router.put("/api/imeis/:id", ({ body, params }, res) => {


### PR DESCRIPTION
## Summary
- add ability to create phone model records from the browser
- expose new API endpoint for phone models
- save phone model info after IMEI data is stored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68557aa797fc832d9acb9d4a8b029e81