### PR TITLE
Improve contrast for brand and model display

### DIFF
--- a/public/funk-enhanced.js
+++ b/public/funk-enhanced.js
@@ -95,8 +95,8 @@ async function renderEnhancedResults(data) {
   const mainDump = `
     <div class="device text-center">
       <img src="${display(data.deviceImage)}" alt="Device Image" style="max-width: 300px;"/>
-      <h1 style="color:#fff;">${display(data.modelName)}</h1>
-      <p style="color:#ccc;">Model: ${display(data.model)}</p>
+      <h1 style="color:#1e293b;">${display(data.modelName)}</h1>
+      <p style="color:#64748b;">Model: ${display(data.model)}</p>
     </div>
     <table class="table table-striped">
       <tr><th>Net Tech</th><td>${display(data.netTech)}</td></tr>

--- a/public/funk.js
+++ b/public/funk.js
@@ -141,7 +141,7 @@ const scoreDump =
 const sampleDump =
     `<div class="device text-center">
       <img src="${display(info.deviceImage)}" alt="Device Image"/>
-      <h1 style="color:#fff;">${display(info.brand)} ${display(info.deviceName)}</h1>
+      <h1 style="color:#1e293b;">${display(info.brand)} ${display(info.deviceName)}</h1>
     </div>
     <table class="table table-striped">
       <tr><th>Net Tech</th><td>${display(info.nettech)}</td></tr>

--- a/public/funk1.js
+++ b/public/funk1.js
@@ -248,7 +248,7 @@ export function processImeiActual(response1, type) {
     <div class="text-center"  >  
     <img src= ${deviceImage} alt=""> 
     </div>
-    <h1 class="text-center" style="color: #aaa;">${deviceName}</h1>
+    <h1 class="text-center" style="color: #1e293b;">${deviceName}</h1>
     </div>
     <table id="w1" class="table table-striped table-bordered detail-view">
     <tbody>  <tr>
@@ -413,7 +413,7 @@ function renderResults(passObject) {
              <img src= ${deviceImage} alt="" 
              > 
              </div>
-             <h1 class="text-center" style="color: #fff;">${brand}  ${deviceName}</h1>` +
+             <h1 class="text-center" style="color: #1e293b;">${brand}  ${deviceName}</h1>` +
 
     `</div><table id="w1" class="table table-striped table-bordered detail-view"><tbody>  <tr>
              
@@ -472,7 +472,7 @@ function displayNoInfo() {
  <div class="text-center"  >  
  <img src= ${deviceImage} alt=""> 
  </div>
- <h1 class="text-center" style="color: #aaa;">${deviceName}</h1>
+ <h1 class="text-center" style="color: #1e293b;">${deviceName}</h1>
  </div>
  <table id="w1" class="table table-striped table-bordered detail-view">
  <tbody>  <tr>


### PR DESCRIPTION
Change text colors from light (#fff, #ccc, #aaa) to dark (#1e293b, #64748b) to ensure proper contrast against the light background (#f8fafc).